### PR TITLE
Test helper for itexia master

### DIFF
--- a/extensions/DatatypeTrait.php
+++ b/extensions/DatatypeTrait.php
@@ -36,7 +36,7 @@ trait DatatypeTrait {
             return 'integer';
         }
 
-        if (preg_match('/^[+-]?([0-9]*[.])?([0-9]|[.][0-9])+$/', $value)) {
+        if (preg_match('/(^[+-]?$)|(^[+-]?[0-9]+([,.][0-9])?[0-9]*(e[+-]?[0-9]+)?$)/', $value)) {
             return 'float';
         }
 

--- a/extensions/DatatypeTrait.php
+++ b/extensions/DatatypeTrait.php
@@ -74,11 +74,16 @@ trait DatatypeTrait {
      *
      * @access public
      *
+     * @uses getDatatypeFromString
+     *
      * @return array|bool
      */
     public function getDatatypes() {
         if (empty($this->data)) {
             $this->data = $this->parse_string();
+        }
+        if (!is_array($this->data)) {
+            throw new \Exception('No data set yet.');
         }
 
         $result = [];

--- a/tests/methods/ParseTest.php
+++ b/tests/methods/ParseTest.php
@@ -132,7 +132,7 @@ class ParseTest extends PHPUnit\Framework\TestCase {
      * @depends testSepRowAutoDetection
      */
     public function testGetColumnDatatypes() {
-        $this->csv->auto('tests/methods/fixtures/datatype.csv');
+        $this->csv->auto(__DIR__ . '/fixtures/datatype.csv');
         $this->csv->getDatatypes();
         $expected = [
             'title' => 'string',

--- a/tests/methods/fixtures/datatype.csv
+++ b/tests/methods/fixtures/datatype.csv
@@ -1,5 +1,5 @@
 sep=;
-title;isbn;publishedAt;published;count;price;
+title;isbn;publishedAt;published;count;price
 Красивая кулинария;5454-5587-3210;21.05.2011;true;1;10.99
 The Wine Connoisseurs;2547-8548-2541;12.12.2011;TRUE;;20,33
 Weißwein;1313-4545-8875;23.02.2012;false;10;10

--- a/tests/properties/worthless_test.php
+++ b/tests/properties/worthless_test.php
@@ -65,7 +65,7 @@ class worthless_properties_Test extends PHPUnit\Framework\TestCase {
      * @access public
      */
     public function test_propertiesCount() {
-        $this->assertCount(28, $this->properties);
+        $this->assertCount(29, $this->properties);
     }
 
     /**


### PR DESCRIPTION
For the master branch of itexia/parsecsv-for-php, the tests are now all green. I ran `phpunit -c tests/phpunit.xml` from the reposs main dir. 

One of the surprises was that German dates were detected to be float by `getDatatypeFromString`. I copy-pasted the regular expression from RingDat Online in.

@susgo we certainly can write a test in this repo for that regular expression. Let's build it from this snippet I wrote many moons ago:

````php
$this->assertEquals(false, isValidNumericString('e'));
$this->assertEquals(false, isValidNumericString('d3.3'));
$this->assertEquals(false, isValidNumericString('1e'));
$this->assertEquals(true, isValidNumericString('1e3'));
$this->assertEquals(true, isValidNumericString('< 0.1'));
$this->assertEquals(true, isValidNumericString('0'));
$this->assertEquals(false, isValidNumericString(',4'));
$this->assertEquals(true, isValidNumericString('0,4'));
$this->assertEquals(false, isValidNumericString('.4'));
$this->assertEquals(false, isValidNumericString('.0'));
$this->assertEquals(true, isValidNumericString('0.4'));
$this->assertEquals(true, isValidNumericString('<< 4'));
$this->assertEquals(false, isValidNumericString('<'));
$this->assertEquals(false, isValidNumericString('--4'));
$this->assertEquals(true, isValidNumericString('-4'));
$this->assertEquals(true, isValidNumericString('+4'));
$this->assertEquals(true, isValidNumericString('0.0'));
````

Let me know if this is not helpful and you want me to start my work from a different branch in the itexia/parsecsv-for-php repo.