### PR TITLE
Repair tests (somewhat)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
   - 5.4
 
 script:
+  - phpunit --version
   - phpunit --configuration tests/phpunit.xml
 
 notifications:

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -6,7 +6,7 @@ if (!file_exists('vendor/autoload.php')) {
 
 require __DIR__ . '/../vendor/autoload.php';
 
-if (!class_exists('PHPUnit\Framework\TestCase')) {
+if (!class_exists('PHPUnit\Framework\TestCase') && class_exists('PHPUnit_Framework_TestCase')) {
     // we run on an older PHPUnit version without namespaces.
     require_once __DIR__ . '/PHPUnit_Framework_TestCase.inc.php';
 }

--- a/tests/properties/DefaultValuesPropertiesTest.php
+++ b/tests/properties/DefaultValuesPropertiesTest.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace ParseCsv\tests\properties;
 
 use ParseCsv\Csv;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class default_values_properties_Test extends TestCase {
 

--- a/tests/properties/DefaultValuesPropertiesTest.php
+++ b/tests/properties/DefaultValuesPropertiesTest.php
@@ -5,7 +5,7 @@ namespace ParseCsv\tests\properties;
 use ParseCsv\Csv;
 use PHPUnit\Framework\TestCase;
 
-class default_values_properties_Test extends TestCase {
+class DefaultValuesPropertiesTest extends TestCase {
 
     /**
      * CSV

--- a/tests/properties/PublicPropertiesTest.php
+++ b/tests/properties/PublicPropertiesTest.php
@@ -5,7 +5,7 @@ namespace ParseCsv\tests\properties;
 use ParseCsv\Csv;
 use PHPUnit\Framework\TestCase;
 
-class DefaultValuesTest extends TestCase {
+class PublicPropertiesTest extends TestCase {
 
     /**
      * CSV

--- a/tests/properties/PublicPropertiesTest.php
+++ b/tests/properties/PublicPropertiesTest.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace ParseCsv\tests\properties;
 
 use ParseCsv\Csv;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class DefaultValuesTest extends TestCase {
 


### PR DESCRIPTION
This pull request gets rid of the nasty ` Class 'PHPUnit_Framework_TestCase' not found` error.

Mmmh, the tests still don't do what they should. @susgo I think you should take over here, as it touches the content and purpose of your code.

PHP 7.1.11 with PHPUnit 7.0.0, 3.7.21 and 6.4.3 all say this on my computer locally and on Travis CI:

````diff
There was 1 failure:

1) ParseCsv\tests\methods\ParseTest::testGetColumnDatatypes
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'title' => 'string'
     'isbn' => 'string'
     'publishedAt' => 'date'
     'published' => 'boolean'
-    'count' => 'integer'
-    'price' => 'float'
+    'count' => 0
+    'price' => 'integer'
 )
````