### PR TITLE
Fixed remaining test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# parseCSV
+# ParseCsv
 
-parseCSV is an easy to use PHP class that reads and writes CSV data properly. It
+ParseCsv is an easy to use PHP class that reads and writes CSV data properly. It
 fully conforms to the specifications outlined on the on the
 [Wikipedia article][CSV] (and thus RFC 4180). It has many advanced features which help make your
 life easier when dealing with CSV data.
 
-You may not need a library at all: before using parseCSV, please make sure if PHP's own `str_getcsv()`, ``fgetcvs()`` or `fputcsv()` meets your needs.
+You may not need a library at all: before using ParseCsv, please make sure if PHP's own `str_getcsv()`, ``fgetcvs()`` or `fputcsv()` meets your needs.
 
 This library was originally created in early 2007 by [jimeh](https://github.com/jimeh) due to the lack of built-in
 and third-party support for handling CSV data in PHP.
@@ -25,8 +25,7 @@ require_once 'parsecsv.lib.php';
 
 ## Features
 
-* parseCSV is the only complete and fully featured CSV solution for PHP (as
-  far as I know).
+* ParseCsv is a complete and fully featured CSV solution for PHP
 * Supports enclosed values, enclosed commas, double quotes and new lines.
 * Automatic delimiter character detection.
 * Sort data by specific fields/columns.
@@ -46,14 +45,14 @@ require_once 'parsecsv.lib.php';
 **General**
 
 ```php
-$csv = new parseCSV('data.csv');
+$csv = new ParseCsv\Csv('data.csv');
 print_r($csv->data);
 ```
 
 **Tab delimited, and encoding conversion**
 
 ```php
-$csv = new parseCSV();
+$csv = new ParseCsv\Csv();
 $csv->encoding('UTF-16', 'UTF-8');
 $csv->delimiter = "\t";
 $csv->parse('data.tsv');
@@ -63,7 +62,7 @@ print_r($csv->data);
 **Auto-detect delimiter character**
 
 ```php
-$csv = new parseCSV();
+$csv = new ParseCsv\Csv();
 $csv->auto('data.csv');
 print_r($csv->data);
 ```
@@ -71,7 +70,7 @@ print_r($csv->data);
 **Modify data in a CSV file**
 
 ```php
-$csv = new parseCSV();
+$csv = new ParseCsv\Csv();
 $csv->sort_by = 'id';
 $csv->parse('data.csv');
 # "4" is the value of the "id" column of the CSV row
@@ -82,7 +81,7 @@ $csv->save();
 **Replace field names or set ones if missing**
 
 ```php
-$csv = new parseCSV();
+$csv = new ParseCsv\Csv();
 $csv->fields = ['id', 'name', 'category']
 $csv->parse('data.csv');
 ```
@@ -92,7 +91,7 @@ $csv->parse('data.csv');
 _Only recommended when you know the exact structure of the file._
 
 ```php
-$csv = new parseCSV();
+$csv = new ParseCsv\Csv();
 $csv->save('data.csv', array(array('1986', 'Home', 'Nowhere', '')), true);
 ```
 
@@ -100,7 +99,7 @@ $csv->save('data.csv', array(array('1986', 'Home', 'Nowhere', '')), true);
 a file and download it**
 
 ```php
-$csv = new parseCSV();
+$csv = new ParseCsv\Csv();
 $csv->output('movies.csv', $array, array('field 1', 'field 2'), ',');
 ```
 
@@ -108,7 +107,7 @@ For more complex examples, see the ``tests`` and `examples` directories.
 
 ## Credits
 
-* parseCSV is based on the concept of [Ming Hong Ng][ming]'s [CsvFileParser][]
+* ParseCsv is based on the concept of [Ming Hong Ng][ming]'s [CsvFileParser][]
   class.
 
 [ming]: http://minghong.blogspot.com/

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,11 @@
             "ParseCsv\\tests\\": "tests"
         }
     },
+    "autoload-dev":{
+        "psr-4":{
+            "ParseCsv\\tests\\": "tests"
+        }
+    },
     "require-dev": {
         "phpunit/phpunit": "4.1.*"
     }

--- a/src/enums/DatatypeEnum.php
+++ b/src/enums/DatatypeEnum.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ParseCsv\enums;
 
 /**
@@ -8,8 +9,7 @@ namespace ParseCsv\enums;
  *
  * todo: needs a basic parent enum class for error handling.
  */
-class DatatypeEnum
-{
+class DatatypeEnum {
 
     const __DEFAULT = self::TYPE_STRING;
 
@@ -39,7 +39,7 @@ class DatatypeEnum
         self::TYPE_INT => 'isValidInteger',
         self::TYPE_BOOL => 'isValidBoolean',
         self::TYPE_FLOAT => 'isValidFloat',
-        self::TYPE_DATE => 'isValidDate'
+        self::TYPE_DATE => 'isValidDate',
     );
 
     /**
@@ -49,15 +49,15 @@ class DatatypeEnum
      *
      * @return bool|string
      */
-    public static function getValidTypeFromSample($value){
+    public static function getValidTypeFromSample($value) {
         $value = trim((string) $value);
 
-        if (empty($value)){
+        if (empty($value)) {
             return false;
         }
 
-        foreach (self::$validators as $type => $validator){
-            if ($validator === null){
+        foreach (self::$validators as $type => $validator) {
+            if ($validator === null) {
                 continue;
             }
 

--- a/src/enums/DatatypeEnum.php
+++ b/src/enums/DatatypeEnum.php
@@ -33,6 +33,11 @@ class DatatypeEnum {
      * Define validator functions here.
      *
      * @var array
+     *
+     * @uses isValidFloat
+     * @uses isValidInteger
+     * @uses isValidBoolean
+     * @uses isValidDate
      */
     private static $validators = array(
         self::TYPE_STRING => null,
@@ -61,10 +66,8 @@ class DatatypeEnum {
                 continue;
             }
 
-            if (method_exists(__CLASS__, $validator)){
-                if (get_class()::$validator($value)) {
-                    return $type;
-                }
+            if (method_exists(__CLASS__, $validator) && self::$validator($value)) {
+                return $type;
             }
         }
 

--- a/src/extensions/DatatypeTrait.php
+++ b/src/extensions/DatatypeTrait.php
@@ -23,20 +23,15 @@ trait DatatypeTrait {
      *
      * @return string|false
      */
-        array_filter($datatypes);
     private function getMostFrequentDatatypeForColumn($datatypes) {
+        // remove 'false' from array (can happen if CSV cell is empty)
+        $types_filtered = array_filter($datatypes);
 
-        if (empty($datatypes)){
+        if (empty($types_filtered)) {
             return false;
         }
 
-        // workaround because array_count_values($datatypes) does not work anymore :-(
-        foreach ($datatypes as $type) {
-            $ids = array_keys($datatypes, $type);
-            $typesFreq[$type] = count($ids);
-
-            $datatypes = array_diff_key($datatypes, array_flip($ids));
-        }
+        $typesFreq = array_count_values($types_filtered);
         arsort($typesFreq);
         reset($typesFreq);
 

--- a/src/extensions/DatatypeTrait.php
+++ b/src/extensions/DatatypeTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ParseCsv\extensions;
 
 trait DatatypeTrait {
@@ -22,8 +23,8 @@ trait DatatypeTrait {
      *
      * @return string|false
      */
-    private function getMostFrequentDataypeForColumn($datatypes) {
         array_filter($datatypes);
+    private function getMostFrequentDatatypeForColumn($datatypes) {
 
         if (empty($datatypes)){
             return false;
@@ -64,10 +65,9 @@ trait DatatypeTrait {
         $result = [];
         foreach ($this->titles as $cName) {
             $column = array_column($this->data, $cName);
-
             $cDatatypes = array_map('ParseCsv\enums\DatatypeEnum::getValidTypeFromSample', $column);
 
-            $result[$cName] = $this->getMostFrequentDataypeForColumn($cDatatypes);
+            $result[$cName] = $this->getMostFrequentDatatypeForColumn($cDatatypes);
         }
 
         $this->data_types = $result;

--- a/src/extensions/DatatypeTrait.php
+++ b/src/extensions/DatatypeTrait.php
@@ -45,7 +45,7 @@ trait DatatypeTrait {
      *
      * @access public
      *
-     * @uses getDatatypeFromString
+     * @uses   getDatatypeFromString
      *
      * @return array|bool
      */
@@ -54,7 +54,7 @@ trait DatatypeTrait {
             $this->data = $this->parse_string();
         }
         if (!is_array($this->data)) {
-            throw new \Exception('No data set yet.');
+            throw new \UnexpectedValueException('No data set yet.');
         }
 
         $result = [];

--- a/src/extensions/DatatypeTrait.php
+++ b/src/extensions/DatatypeTrait.php
@@ -43,6 +43,8 @@ trait DatatypeTrait {
      * Check data type foreach Column
      * Check data type for each column and returns the most commonly.
      *
+     * Requires PHP >= 5.5
+     *
      * @access public
      *
      * @uses   getDatatypeFromString

--- a/tests/methods/ParseTest.php
+++ b/tests/methods/ParseTest.php
@@ -137,6 +137,12 @@ class ParseTest extends TestCase
      * @depends testSepRowAutoDetection
      */
     public function testGetColumnDatatypes() {
+        if (!function_exists('array_column')) {
+            // getDatatypes requires array_column, but that
+            // function is only available in PHP >= 5.5
+            return;
+        }
+
         $this->csv->auto(__DIR__ . '/fixtures/datatype.csv');
         $this->csv->getDatatypes();
         $expected = [


### PR DESCRIPTION
This pull request fixed the funny test output of [pull request 5](https://github.com/itexia/parsecsv-for-php/pull/5#issue-170061344).

I suspect the cause was a buggy replacement of `array_count_values`, so this pull request actually fixes a problem with the type detecting for the case of empty cells (e.g. for `parsecsv-for-php\tests\methods\fixtures\datatype.csv` if not every row has a number for the "count" column). 

In `getMostFrequentDatatypeForColumn` your code didn't do anything with the `array_filter` return value. By using it, I could use `array_count_values` again, which fixed the difference in the test code.